### PR TITLE
Add the condition to check if logging is defined as "none"

### DIFF
--- a/roles/project_deployment/templates/docker-compose.yml.j2
+++ b/roles/project_deployment/templates/docker-compose.yml.j2
@@ -61,7 +61,7 @@ services:
       start_period: {{ current_service.healthcheck.start_period }}
 {% endif %}
 {% endif %}
-{% if current_service.logging is defined %}
+{% if current_service.logging is defined and current_service.logging is not none %}
     logging:
       driver: {{ current_service.logging.driver }}
 {% if current_service.logging.options is defined and current_service.logging.options is not none %}


### PR DESCRIPTION
If this condition is missing, then the other solution is to delete the logging part from the template and define the whole docker-compose.yml variables on each hosts, where logging should be enabled. Therefore adding a condition to chechk if the value of the variable is not none, it can be easily adopted to each docker project.