### PR TITLE
Add internal network option

### DIFF
--- a/roles/project_deployment/templates/docker-compose.yml.j2
+++ b/roles/project_deployment/templates/docker-compose.yml.j2
@@ -72,12 +72,14 @@ services:
 {% endif %}
 {% endif %}
 {% endfor %}
-{% if current_project.value.external_networks is defined and current_project.value.external_networks | length > 0 %}
+{% if current_project.value.networks is defined and current_project.value.networks | length > 0 %}
 
 networks:
-{% for external_network in current_project.value.external_networks %}
-  {{ external_network }}:
+{% for network in current_project.value.networks %}
+  {{ network }}:
+{% if current_project.value.external_networks is defined and current_project.value.external_networks | length > 0 and network in current_project.value.external_networks %}
     external: true
+{% endif %}
 {% endfor %}
 {% endif %}
 {% if docker_volumes is defined and docker_volumes | length > 0 %}


### PR DESCRIPTION
Sometimes it is possible, that one or more networks are external and the other(s) not. In that case, we have to be able to differentiate between these networks in docker-compose.yml file. To do that, I have set another variable and condition, and put the external check in that condition.