### PR TITLE
Add effective owner for file

### DIFF
--- a/roles/project_deployment/tasks/deploy_file.yml
+++ b/roles/project_deployment/tasks/deploy_file.yml
@@ -12,6 +12,11 @@
   ansible.builtin.set_fact:
     remote_path: "{{ project_dir + '/' + (file.path.split(project_name + '/')[1:] | join(project_name + '/')).split('.j2')[0] }}"
 
+- name: "Set effective owner for file"
+  ansible.builtin.set_fact:
+    project_deployment_file_owner: "{{ project_deployment_file_owner_overrides[file.path | basename].owner | default(project_deployment_owner) }}"
+    project_deployment_file_group: "{{ project_deployment_file_owner_overrides[file.path | basename].group | default(project_deployment_group) }}"
+
 - name: "Copy file if no host_file exists or copy host_file"
   ansible.builtin.copy:
     src: "{{ file.path }}"
@@ -19,8 +24,8 @@
     mode: "{{ project_deployment_file_mode if not \
       remote_path | ifalatik.docker.any_regex_matches(regex_secret_remote_paths) \
       else project_deployment_secret_file_mode }}"
-    owner: "{{ project_deployment_owner }}"
-    group: "{{ project_deployment_group }}"
+    owner: "{{ project_deployment_file_owner }}"
+    group: "{{ project_deployment_file_group }}"
   become: true
   diff: "{{ not remote_path | ifalatik.docker.any_regex_matches(regex_secret_remote_paths) }}"
   when: file_type == 'host_file' or


### PR DESCRIPTION
Sometimes it is needed to set ownership other than project_deployment_owner and group. At this point, we should be able to separately define it. With this PR, it is possible to set file specific ownership by setting an effective ownership. 

The wanted change can then be applied in any level of variables  as dictionary as follows:

project_deployment_file_owner_overrides:
  "file_1":
      owner: "user_1"
      group: "group_1"

  "file_2":
      owner: "user_2"
      group: "group_1"

It could be extended for other variables as well, but since it was necessary only for file ownership, the PR includes only changes at this scope.